### PR TITLE
Rename to aws-appsync-events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "events",
+	"name": "aws-appsync-events",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
Removes potential conflict with built-in "events" module that npm warns about: "warning package.json: "events" is also the name of a node core module"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
